### PR TITLE
docs(usage): Update the parameter to be correct as initialised in `GenerationBase`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ models locally, for example:
 
 ```python
 
-from rago.core import Rago
+from rago import Rago
 from rago.generation import LlamaGen
 from rago.retrieval import StringRet
 from rago.augmented import SentenceTransformerAug
@@ -81,7 +81,7 @@ animals_data = [
 rag = Rago(
     retrieval=StringRet(animals_data),
     augmented=SentenceTransformerAug(top_k=2),
-    generation=LlamaGen(apikey=HF_TOKEN),
+    generation=LlamaGen(api_key=HF_TOKEN),
 )
 rag.prompt('What is the faster animal on Earth?')
 ```


### PR DESCRIPTION
When I was testing Rago earlier, I tested it with a non gated model and didn't need to pass the `api_key` parameter. But I tried using llama as the generation model today and from the example in the `README`, I passed the `HF_TOKEN` to `apikey` and got an error. `api_key` is what it is initialised with in the `GenerationBase` class, so in this PR I have updated the example to avoid any confusion for users and contributors.