### PR TITLE
Fix: Typo and API Key Handling in Tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,9 +59,7 @@ def api_key_hugging_face(env: dict[str, str]) -> str:
     """Fixture for Hugging Face API key from environment."""
     api_key = os.getenv('HF_TOKEN')
     if not api_key:
-        raise EnvironmentError(
-            'Please set the GEMINI_API_KEY environment variable.'
-        )
+        raise EnvironmentError('Please set the HF_TOKEN environment variable.')
     return api_key
 
 

--- a/tests/test_ext_cache.py
+++ b/tests/test_ext_cache.py
@@ -72,7 +72,7 @@ def api_keys(env) -> {str, str}:
     ],
 )
 def test_cache(
-    animals_data: list[str], api_keys: str, aug_class: partial
+    animals_data: list[str], api_keys: dict[str, str], aug_class: partial
 ) -> None:
     """Test RAG pipeline with OpenAI's GPT."""
     api_name = aug_class.func.__name__


### PR DESCRIPTION
Just a small PR to correct API key type annotations. Ensures api_keys is correctly treated as a dictionary to prevent attribute errors.
Also corrected a typo in the tests that could create confusion.