### PR TITLE
feat(generation): add backend support for HuggingFace using inference

### DIFF
--- a/src/rago/generation/__init__.py
+++ b/src/rago/generation/__init__.py
@@ -8,6 +8,7 @@ from rago.generation.deepseek import DeepSeekGen
 from rago.generation.fireworks import FireworksGen
 from rago.generation.gemini import GeminiGen
 from rago.generation.hugging_face import HuggingFaceGen
+from rago.generation.hugging_face_inf import HuggingFaceInfGen
 from rago.generation.llama import LlamaGen
 from rago.generation.openai import OpenAIGen
 from rago.generation.together import TogetherGen
@@ -19,6 +20,7 @@ __all__ = [
     'GeminiGen',
     'GenerationBase',
     'HuggingFaceGen',
+    'HuggingFaceInfGen',
     'LlamaGen',
     'OpenAIGen',
     'TogetherGen',

--- a/src/rago/generation/hugging_face_inf.py
+++ b/src/rago/generation/hugging_face_inf.py
@@ -1,0 +1,49 @@
+"""Hugging Face inferencing classes for text generation."""
+
+from __future__ import annotations
+
+from huggingface_hub import InferenceClient
+from pydantic import BaseModel
+from typeguard import typechecked
+
+from rago.generation.base import GenerationBase
+
+
+@typechecked
+class HuggingFaceInfGen(GenerationBase):
+    """HuggingFaceGen with InferenceClient."""
+
+    default_model_name: str = 'google/gemma-2-2b-it'
+    default_api_params = {  # noqa: RUF012
+        'temperature': 0.7,
+        'max_new_tokens': 512,
+    }
+
+    def _setup(self) -> None:
+        """Set up InferenceClient with API key."""
+        self.client = InferenceClient(
+            provider='hf-inference', api_key=self.api_key
+        )
+
+    def generate(self, query: str, context: list[str]) -> str | BaseModel:
+        """Generate the text from the query and augmented context."""
+        input_text = self.prompt_template.format(
+            query=query, context=' '.join(context)
+        )
+        if self.system_message:
+            input_text = f'{self.system_message}\n{input_text}'
+
+        api_params = self.api_params or self.default_api_params
+
+        self.logs['model_params'] = {
+            'model': self.model_name,
+            'inputs': input_text,
+            'parameters': api_params,
+        }
+        generated_text = self.client.text_generation(
+            prompt=input_text,
+            model=self.model_name,
+            max_new_tokens=api_params['max_new_tokens'],
+            temperature=api_params['temperature'],
+        )
+        return generated_text.strip()

--- a/src/rago/generation/hugging_face_inf.py
+++ b/src/rago/generation/hugging_face_inf.py
@@ -46,4 +46,5 @@ class HuggingFaceInfGen(GenerationBase):
             max_new_tokens=api_params['max_new_tokens'],
             temperature=api_params['temperature'],
         )
+
         return generated_text.strip()

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -11,6 +11,7 @@ from rago.generation import (
     FireworksGen,
     GeminiGen,
     HuggingFaceGen,
+    HuggingFaceInfGen,
     LlamaGen,
     OpenAIGen,
     TogetherGen,
@@ -26,6 +27,7 @@ API_MAP = {
     GeminiGen: 'api_key_gemini',
     OpenAIGen: 'api_key_openai',
     HuggingFaceGen: 'api_key_hugging_face',
+    HuggingFaceInfGen: 'api_key_hugging_face',
     LlamaGen: 'api_key_hugging_face',
     CohereGen: 'api_key_cohere',
     FireworksGen: 'api_key_fireworks',
@@ -74,9 +76,14 @@ gen_models = [
     partial(
         FireworksGen,
     ),
+    # model 7
     partial(
         TogetherGen,
         **dict(model_name='meta-llama/Llama-3.3-70B-Instruct-Turbo-Free'),
+    ),
+    # model 8
+    partial(
+        HuggingFaceInfGen,
     ),
 ]
 
@@ -152,7 +159,9 @@ def test_generation_structure_output(
     model_class = partial_model.func
 
     # Skip structured output for models that don't support it
-    if issubclass(model_class, (HuggingFaceGen, LlamaGen, DeepSeekGen)):
+    if issubclass(
+        model_class, (HuggingFaceGen, LlamaGen, HuggingFaceInfGen, DeepSeekGen)
+    ):
         pytest.skip(f"{model_class} doesn't support structured output.")
 
     api_key_name: str = API_MAP.get(model_class, '')


### PR DESCRIPTION
## Pull Request description
This PR introduces Hugging Face inference capabilities into Rago. we have implemented inference using `huggingface_hub`, expanding Rago's versatility in handling various NLP tasks Also letting people use various finetuned models without hosting those models on their own device!.
<!-- Describe the purpose of your PR and the changes you have made. -->
@xmnlab sir This PR extends Rago's capabilities by adding support for additional backend provider for text generation.
<!-- Which issue this PR aims to resolve or fix? E.g.:
Solving issue https://github.com/osl-incubator/rago/issues/35 partially I can add more support for the backend once this PR is reviewed
-->

## How to test these changes
I have added test for the same in test_generation file!
Note: As hugging_face hub is a part of transformer library we don't need to add it to pyproject.toml or poetry.lock file.
<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [x] pre-commit hooks were executed locally.
- [x] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->


## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [x] I managed to test the new changes locally
- [x] I confirm that the issues mentioned were fixed/resolved .
